### PR TITLE
Don't change function prototypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const GithubWebhook = function(options) {
 	options.secret = options.secret || '';
 
 	// Make handler able to emit events
-	Object.setPrototypeOf(githookHandler, EventEmitter.prototype);
+	Object.assign(githookHandler, EventEmitter.prototype);
 	EventEmitter.call(githookHandler);
 
 	return githookHandler;


### PR DESCRIPTION
By changing the function's prototype to `EventEmitter` you remove access to `.apply` and `.call`. While this does not affect usage in Express it does affect things that instrument Express and expect all middleware to be `.apply`able.