### PR TITLE
Allow configuring header names and signature function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Available options for creating handler are:
 
 * path: the path for the GitHub callback, only request that matches this path will be handled by the middleware.
 * secret (option): the secret used to verify the signature of the hook. If secret is set, then request without signature will fail the handler. If secret is not set, then the signature of the request (if any) will be ignored. [Read more](https://developer.github.com/webhooks/securing/)
+* deliveryHeader (option): header name for the delivery ID, defaults to `x-github-delivery`
+* eventHeader (option): header name for the event type, defaults to `x-github-event`
+* signatureHeader (option): header name for the event signature, defaults to `x-hub-signature`
+* signData (option): signature function used to compute and check event signatures, defaults to GitHub SHA1 HMAC signature. Will receive the secret and data to sign as arguments.
 
 
 TODO


### PR DESCRIPTION
This adds 4 new options:
* `deliveryHeader`, `eventHeader`, `signatureHeader` to customize headers
* `signData` to customize the signature function